### PR TITLE
check timestamp before loading pickle

### DIFF
--- a/bin/visualqa.py
+++ b/bin/visualqa.py
@@ -138,6 +138,14 @@ def load_dataset(dataset_type, options, answer_one_hot_mapping = None):
     if (dataset_type != DatasetType.TRAIN):
         assert(answer_one_hot_mapping != None) 
 
+    # If pickle file is older than dataset.py, delete and recreate
+    print('Checking timestamp on dataset -> {}'.format(dataset_path))
+    dataset_py_path = os.path.abspath('../vqa/dataset/dataset.py')
+    if os.path.isfile(dataset_path) and \
+    os.path.getmtime(dataset_path) < os.path.getmtime(dataset_py_path):
+        os.remove(dataset_path)
+        print('Dataset was outdated.  Removed ->', dataset_path)
+
     try:
         with open(dataset_path, 'rb') as f:
             print('Loading dataset from {}'.format(dataset_path))

--- a/requirements.pip
+++ b/requirements.pip
@@ -7,3 +7,4 @@ keras-preprocessing==1.0.5
 mlflow==0.8.0
 tensorboard==1.10.0   
 tensorflow==1.10.1
+tensorflow-gpu==1.10.1

--- a/vqa/dataset/dataset.py
+++ b/vqa/dataset/dataset.py
@@ -4,6 +4,7 @@
 # Added Memory management related code for Image Embeddings
 
 import h5py
+import inspect
 import json
 import math
 import numpy as np
@@ -86,14 +87,21 @@ class VQADataset:
         self.n_answer_classes = self.options['n_answer_classes']
 
         # Tokenizer path (pickle file previously generated in prepare() method)
-        self.tokenizer_path = self.options['tokenizer_path']
+        self.tokenizer_path = os.path.abspath(self.options['tokenizer_path'])
         print("Tokenizer path -> ", self.tokenizer_path)
         # if directory doesn't exist, create it
-        tokenizer_dir = os.path.dirname(os.path.abspath(self.tokenizer_path))
+        tokenizer_dir = os.path.dirname(self.tokenizer_path)
         print("Tokenizer directory -> ", tokenizer_dir)
         if not os.path.isdir(tokenizer_dir):
             os.mkdir(tokenizer_dir)
-
+            
+        # If Tokenizer pickle file is older than dataset.py, delete and recreate
+        dataset_py_path = os.path.abspath(inspect.stack()[0][1])
+        if os.path.isfile(self.tokenizer_path) and \
+        os.path.getmtime(self.tokenizer_path) < os.path.getmtime(dataset_py_path):
+            os.remove(self.tokenizer_path)
+            print('Tokenizer was outdated.  Removed ->', self.tokenizer_path)
+        
         # Load pre-trained Tokenizer if one exists
         if os.path.isfile(self.tokenizer_path):
             self.tokenizer = pickle.load(open(self.tokenizer_path, 'rb'))

--- a/vqa/model/options.py
+++ b/vqa/model/options.py
@@ -43,10 +43,11 @@ class ModelOptions(object):
 #         self.options['glove_path'] = ''
 
         ## files created during train/val/test phases
-        self.options['local_data_path']  =  "../data/preprocessed/"
-        self.options['saved_models_path'] = '../saved_models/json/'
-        self.options['weights_dir_path'] =  "../saved_models/weights/"
-        self.options['results_dir_path'] =  "../results/"
+        # NOTE: os.path.abspath drops trailing slash, so need to re-add
+        self.options['local_data_path']  =  os.path.abspath("../data/preprocessed") + '/'
+        self.options['saved_models_path'] = os.path.abspath('../saved_models/json') + '/'
+        self.options['weights_dir_path'] =  os.path.abspath("../saved_models/weights") + '/'
+        self.options['results_dir_path'] =  os.path.abspath("../results") + '/'
 
         ## create directories if they don't exist
         os.makedirs(self.options['local_data_path'],   exist_ok=True)


### PR DESCRIPTION
This should save us all of those errors that get raised when loading an old pickle file after the class definition has changed.

Fixes #86 