### PR TITLE
read experiments from json

### DIFF
--- a/bin/visualqa.py
+++ b/bin/visualqa.py
@@ -524,7 +524,6 @@ if __name__ == '__main__':
         '--experiment',
         type=int,
         default=DEFAULT_EXPERIMENT,
-        choices=ExperimentLibrary.get_valid_experiment_ids(),
         help='Specify the experiment configuration ID. Omitting argument or selecting 0 means no experiment.'
     )
 
@@ -532,45 +531,41 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # load model options from config file
-    model_options = ModelOptions().get_options()
+    options = ModelOptions().get_options()
     
     # disable logging to MLFlow server; usually only used for debugging
     if args.no_logging:
-        model_options['logging'] = False
+        options['logging'] = False
 
     # override default for max_epochs if specified
     if args.epochs:
-        model_options['max_epochs'] = args.epochs
+        options['max_epochs'] = args.epochs
         
     # override default for batch_size if specified
     if args.batch_size:
-        model_options['batch_size'] = args.batch_size
+        options['batch_size'] = args.batch_size
 
     # parse args with defaults
-    model_options['model_name'] = args.model 
-    model_options['action_type'] = args.action
+    options['model_name'] = args.model 
+    options['action_type'] = args.action
 
-    model_options['max_train_size'] = args.max_train_size
-    model_options['max_val_size']   = args.max_val_size
+    options['max_train_size'] = args.max_train_size
+    options['max_val_size']   = args.max_val_size
 
     # set the optimizer params (learning rate, etc...)
-    ModelOptions.set_optimizer_params(model_options)
+    ModelOptions.set_optimizer_params(options)
     
     # process experiments last
     # load experiment attributes from json (overrides model defaults and CLI args)
     if args.experiment:
-        model_options = ExperimentLibrary.get_experiment(args.experiment, model_options)
+        options = ExperimentLibrary.get_experiment(args.experiment, options)
     
     # print all options before building graph
     if args.verbose:
-        model_options['verbose'] = args.verbose
-        pprint.pprint(model_options)
+        options['verbose'] = args.verbose
+        pprint.pprint(options)
 
-#     if model_options['logging']:
-#         # create a new experiment in MLFlow if one doesn't exist
-#         mlflow.set_experiment(model_options['experiment_name'])
-
-    main(model_options)
+    main(options)
 
     print('Completed!')
 

--- a/vqa/experiments/experiment_1.json
+++ b/vqa/experiments/experiment_1.json
@@ -1,0 +1,10 @@
+{
+  "experiment_id": 1,
+  "experiment_name": "Text_only_CNN",
+  "model_name": "text_cnn",
+  "optimizer": "sgd",
+  "sgd_learning_rate": 0.1,
+  "sgd_momentum": 0.9,
+  "sgd_decay_rate": 0.0, 
+  "sgd_grad_clip": 0.1        
+}

--- a/vqa/experiments/experiment_select.py
+++ b/vqa/experiments/experiment_select.py
@@ -1,10 +1,12 @@
+import json
+
 from vqa import BASE_DIR
+from vqa.model.model_select import ModelLibrary
 
 class ExperimentLibrary:
     # ---------------------------------- CONSTANTS --------------------------------
     # Model identifiers
     EXPERIMENT_0   = 0  # no experiment
-    EXPERIMENT_1   = 1  # concise description of experiment
 
     # Path
     EXPERIMENTS_PATH = BASE_DIR + 'vqa/experiments/'
@@ -24,17 +26,29 @@ class ExperimentLibrary:
     @staticmethod
     def get_experiment(id, options):
         '''
-            Load corresponding json file and override options defaults
+            Load corresponding json file and override options defaults.  Any key-value pairs in the json
+            file will be added to the options object, overriding existing values.
         '''
         
         print('Setting up experiment {}'.format(id))
         options['experiment_id'] = id
-        
-        # TODO: replace this statement to load experiment_name from json file
-        options['experiment_name'] = 'experiment_{}'.format(id)
+        expt_path = '{}experiment_{}.json'.format(options['experiments_path'], id)
         
         if id != ExperimentLibrary.EXPERIMENT_0:
-            # TODO: load json; save parameters to options
-            pass
-        
+            print('Trying to load json from ->', expt_path)
+            expt_json = json.load(open(expt_path))
+            if not 'experiment_id' in expt_json:
+                raise KeyError('Unique integer \"experiment_id\" must be specified in the experiment json file.')
+            if not 'model_name' in expt_json:
+                raise KeyError('Valid \"model_name\" must be specified in the experiment json file. Choices: {}'.format
+                              (ModelLibrary.get_valid_model_names()))
+            for key, val in expt_json.items():
+                options[key] = val
+            
+        # Make sure every experiment has a name; needed for MLFlow logging
+        if options.get('experiment_name', None) == None:
+            options['experiment_name'] = 'experiment_{}'.format(id)
+        else:
+            options['experiment_name'] = options['experiment_name'].replace(' ', '_')
+
         return options

--- a/vqa/model/options.py
+++ b/vqa/model/options.py
@@ -45,6 +45,7 @@ class ModelOptions(object):
         ## files created during train/val/test phases
         # NOTE: os.path.abspath drops trailing slash, so need to re-add
         self.options['local_data_path']  =  os.path.abspath("../data/preprocessed") + '/'
+        self.options['experiments_path'] =  os.path.abspath("../vqa/experiments") + '/'
         self.options['saved_models_path'] = os.path.abspath('../saved_models/json') + '/'
         self.options['weights_dir_path'] =  os.path.abspath("../saved_models/weights") + '/'
         self.options['results_dir_path'] =  os.path.abspath("../results") + '/'


### PR DESCRIPTION
Fixes #51 

To configure an experiment, make a copy of `vqa\experiments\experiment_1.json` and add/edit parameters.  The only required params are `experiment_id`, `experiment_name`, and `model_name`.  Any other key-value pairs in the file will be added to the `options` object, and will override anything pre-set in `options.py`.